### PR TITLE
Fix three first-dispatch failures in whisper.cpp build workflow

### DIFF
--- a/.github/workflows/build-whispercpp-release.yml
+++ b/.github/workflows/build-whispercpp-release.yml
@@ -111,10 +111,14 @@ jobs:
           ref: ${{ inputs.whisper_ref }}
 
       - name: Install Vulkan SDK
-        uses: humbletim/install-vulkan-sdk@v1.2
+        # 1.3.296.0+ bundles SPIRV-Headers — required by ggml-vulkan's
+        # find_package(SPIRV-Headers). Earlier versions error out at configure.
+        uses: jakoch/install-vulkan-sdk-action@v1
         with:
-          version: 1.3.290.0
+          vulkan_version: 1.3.296.0
+          install_runtime: true
           cache: true
+          stripdown: true
 
       - name: Configure
         shell: pwsh
@@ -171,10 +175,12 @@ jobs:
           ref: ${{ inputs.whisper_ref }}
 
       - name: Install Vulkan SDK + tools
+        # ubuntu-latest is now noble (24.04), so use the noble repo path —
+        # the jammy variant pulls libyaml-cpp0.7 which isn't in noble.
         run: |
           wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list \
-            https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list \
+            https://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
           sudo apt-get update
           sudo apt-get install -y vulkan-sdk libvulkan-dev glslang-tools libsdl2-dev cmake
 
@@ -227,11 +233,14 @@ jobs:
           ref: ${{ inputs.whisper_ref }}
 
       - name: Install CUDA toolkit 12.4
+        # Letting the action install the full toolkit instead of using
+        # `sub-packages`; the package names available via apt vary by
+        # Ubuntu series, and getting them right inside `sub-packages`
+        # is brittle. Full install is ~3 GB but caches on subsequent runs.
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
           cuda: '12.4.0'
           method: network
-          sub-packages: '["nvcc", "cudart", "libcublas-dev", "libcublas"]'
 
       - name: Install build deps
         run: sudo apt-get update && sudo apt-get install -y cmake build-essential


### PR DESCRIPTION
Follow-up to #4: the first dispatch of the workflow ([run](https://github.com/SubtitleEdit/support-files/actions/runs/26689564694)) surfaced three independent setup issues. Fixes:

| Job | Issue | Fix |
|---|---|---|
| **linux-cuda** | \`sub-packages: '[\"nvcc\", \"cudart\", \"libcublas-dev\", \"libcublas\"]'\` ended up requesting \`cuda-nvcc-12-4\` / \`cuda-libcublas-12-4\` etc., which apt on ubuntu-latest=noble cannot resolve | Drop \`sub-packages\` and let the action install the full toolkit. ~3 GB but reliable; runner cache keeps subsequent runs fast. |
| **windows-vulkan** | Vulkan SDK 1.3.290.0 doesn't bundle SPIRV-Headers, which \`find_package(SPIRV-Headers)\` in ggml-vulkan's CMake needs | Bump to 1.3.296.0 and switch to \`jakoch/install-vulkan-sdk-action@v1\` (bundles SPIRV-Headers from .296 onwards) |
| **linux-vulkan** | LunarG \`jammy\` repo pulled \`libyaml-cpp0.7\` as a transitive dep, but ubuntu-latest is now noble (24.04) where that package isn't in the archive | Switch to \`lunarg-vulkan-noble.list\` |

No CMake flag changes; this is purely setup config.

Once merged, dispatch again with the same defaults (\`whisper_ref=v1.8.5\`, \`release_tag=whispercpp-185\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)