### PR TITLE
Fix three more whisper.cpp build failures

### DIFF
--- a/.github/workflows/build-whispercpp-release.yml
+++ b/.github/workflows/build-whispercpp-release.yml
@@ -112,22 +112,28 @@ jobs:
 
       - name: Install Vulkan SDK
         # 1.3.296.0+ bundles SPIRV-Headers — required by ggml-vulkan's
-        # find_package(SPIRV-Headers). Earlier versions error out at configure.
+        # find_package(SPIRV-Headers). `stripdown` removes those CMake config
+        # files, so keep the full install. Runtime install isn't needed for a
+        # headless build.
         uses: jakoch/install-vulkan-sdk-action@v1
         with:
           vulkan_version: 1.3.296.0
-          install_runtime: true
+          install_runtime: false
           cache: true
-          stripdown: true
+          stripdown: false
 
       - name: Configure
+        # Point CMake at the SDK's CMake config tree so find_package(SPIRV-Headers)
+        # resolves to %VULKAN_SDK%\share\cmake\SPIRV-Headers (set by the SDK installer).
         shell: pwsh
         run: |
+          $env:CMAKE_PREFIX_PATH = "$env:VULKAN_SDK;$env:CMAKE_PREFIX_PATH"
           cmake -B build -A x64 `
             -DCMAKE_BUILD_TYPE=Release `
             -DGGML_VULKAN=ON `
             -DWHISPER_SDL2=OFF `
-            -DBUILD_SHARED_LIBS=ON
+            -DBUILD_SHARED_LIBS=ON `
+            -DCMAKE_PREFIX_PATH="$env:VULKAN_SDK"
 
       - name: Build whisper-cli
         shell: pwsh
@@ -185,11 +191,15 @@ jobs:
           sudo apt-get install -y vulkan-sdk libvulkan-dev glslang-tools libsdl2-dev cmake
 
       - name: Configure
+        # GGML_BACKEND_DL is required by GGML_CPU_ALL_VARIANTS — it switches
+        # to a dlopen plugin model so the per-microarch libggml-cpu-*.so
+        # variants can coexist in one install.
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DGGML_VULKAN=ON \
             -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_BACKEND_DL=ON \
             -DGGML_NATIVE=OFF \
             -DWHISPER_SDL2=OFF \
             -DBUILD_SHARED_LIBS=ON
@@ -224,7 +234,10 @@ jobs:
   # we match that exactly.
   # --------------------------------------------------------------------
   linux-cuda:
-    runs-on: ubuntu-latest
+    # Pin to 22.04 because Jimver/cuda-toolkit installs apt packages built
+    # against the runner's libc/libstdc++; on noble (24.04) the `cuda-12-4`
+    # meta package isn't published yet via the network method.
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone whisper.cpp
         uses: actions/checkout@v5
@@ -233,10 +246,6 @@ jobs:
           ref: ${{ inputs.whisper_ref }}
 
       - name: Install CUDA toolkit 12.4
-        # Letting the action install the full toolkit instead of using
-        # `sub-packages`; the package names available via apt vary by
-        # Ubuntu series, and getting them right inside `sub-packages`
-        # is brittle. Full install is ~3 GB but caches on subsequent runs.
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
           cuda: '12.4.0'
@@ -246,11 +255,14 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cmake build-essential
 
       - name: Configure
+        # GGML_BACKEND_DL is required by GGML_CPU_ALL_VARIANTS — see notes in
+        # the linux-vulkan Configure step.
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DGGML_CUDA=ON \
             -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_BACKEND_DL=ON \
             -DGGML_NATIVE=OFF \
             -DWHISPER_SDL2=OFF \
             -DBUILD_SHARED_LIBS=ON


### PR DESCRIPTION
Follow-up to #5: second dispatch ([run](https://github.com/SubtitleEdit/support-files/actions/runs/26689695368)) still failed for the same 3 jobs, with different errors that surfaced after the first-round fixes:

| Job | New error | Fix |
|---|---|---|
| **linux-vulkan** | \`GGML_CPU_ALL_VARIANTS requires GGML_BACKEND_DL\` at configure | Add \`-DGGML_BACKEND_DL=ON\` (whisper.cpp recently switched the per-microarch variants to a dlopen plugin model) |
| **linux-cuda** | Same Configure error once apt got past \`cuda-12-4\` (couldn't even reach the build step — apt: \`Unable to locate package cuda-12-4\` on ubuntu-latest=noble) | Pin runner to \`ubuntu-22.04\` where Jimver's network-method apt path actually resolves, **and** add \`-DGGML_BACKEND_DL=ON\` |
| **windows-vulkan** | \`find_package(SPIRV-Headers)\` still failed with SDK 1.3.296.0 | Remove \`stripdown: true\` (was deleting the SDK's SPIRV-Headers CMake config) + add \`-DCMAKE_PREFIX_PATH=$VULKAN_SDK\` so CMake finds \`%VULKAN_SDK%\share\cmake\SPIRV-Headers\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)